### PR TITLE
Enable ssl verfication via CERT_PATH flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.8.1-alpine3.11 AS builder
 
-LABEL version="1.10"
+LABEL version="1.11"
 LABEL description="Kibana Prometheus exporter"
 LABEL maintainer="Vlad Vasiliu <vladvasiliun@yahoo.fr>"
 

--- a/README.md
+++ b/README.md
@@ -15,15 +15,19 @@ This is a Prometheus exporter for Kibana written in Python.
 
 Configuration is done via environment variables. Available parameters:
 
-|Parameter      |Default|Required|
-|---------------|-------|--------|
-|KIBANA_URL     |-      |Yes     |
-|LISTEN_PORT    |9563   |No      |
-|LOG_LEVEL      |INFO   |No      |
-|KIBANA_LOGIN   |-      |No      |
-|KIBANA_PASSWORD|-      |No      |
+|Parameter          |Default|Required|
+|-------------------|-------|--------|
+|KIBANA_URL         |-      |Yes     |
+|LISTEN_PORT        |9563   |No      |
+|LOG_LEVEL          |INFO   |No      |
+|KIBANA_LOGIN       |-      |No      |
+|KIBANA_PASSWORD    |-      |No      |
+|IGNORE_SSL         |FALSE  |No      |
+|REQUESTS_CA_BUNDLE |-      |No      |
 
 Authentication can also be done via a netrc file. `requests` natively supports this.
+
+You can provide CA bundle for `requests` library using the `REQUESTS_CA_BUNDLE` environment variable
 
 Documentation:
 * [`requests`](http://docs.python-requests.org/en/master/user/authentication/)

--- a/kibana_prometheus_exporter/__main__.py
+++ b/kibana_prometheus_exporter/__main__.py
@@ -21,7 +21,12 @@ except ValueError as e:
 logger.info("Starting Kibana Prometheus exporter version %s\n" % config.version + config.description())
 
 REGISTRY.register(
-    KibanaCollector(config.kibana_url, kibana_login=config.kibana_login, kibana_password=config.kibana_password)
+    KibanaCollector(
+        config.kibana_url,
+        kibana_login=config.kibana_login,
+        kibana_password=config.kibana_password,
+        ignore_ssl=config.ignore_ssl,
+    )
 )
 
 try:

--- a/kibana_prometheus_exporter/_version.py
+++ b/kibana_prometheus_exporter/_version.py
@@ -1,1 +1,1 @@
-VERSION = "1.10"
+VERSION = "1.11"

--- a/kibana_prometheus_exporter/kibana_collector.py
+++ b/kibana_prometheus_exporter/kibana_collector.py
@@ -150,17 +150,30 @@ class Metrics(object):
 
 
 class KibanaCollector(object):
-    def __init__(self, host: str, path: str = "/api/status", kibana_login: str = None, kibana_password: str = None):
+    def __init__(
+        self,
+        host: str,
+        path: str = "/api/status",
+        kibana_login: str = None,
+        kibana_password: str = None,
+        ignore_ssl: str = None,
+    ):
         self._url = url_join(host, path)
         self._kibana_login = kibana_login
         self._kibana_password = kibana_password
+        self._ignore_ssl = ignore_ssl
 
     def _fetch_stats(self) -> dict:
         if self._kibana_login:
             auth = (self._kibana_login, self._kibana_password)
         else:
             auth = None
-        r = get(self._url, auth=auth)
+
+        if self._ignore_ssl == True:
+            r = get(self._url, auth=auth, verify=False)
+        else:
+            r = get(self._url, auth=auth)
+
         r.raise_for_status()
         return r.json()
 

--- a/kibana_prometheus_exporter/kibana_collector.py
+++ b/kibana_prometheus_exporter/kibana_collector.py
@@ -156,7 +156,7 @@ class KibanaCollector(object):
         path: str = "/api/status",
         kibana_login: str = None,
         kibana_password: str = None,
-        ignore_ssl: str = None,
+        ignore_ssl: bool = False,
     ):
         self._url = url_join(host, path)
         self._kibana_login = kibana_login
@@ -170,7 +170,7 @@ class KibanaCollector(object):
             auth = None
 
         if self._ignore_ssl == True:
-            r = get(self._url, auth=auth, verify=False)
+            r = get(self._url, auth=auth, verify=not self._ignore_ssl)
         else:
             r = get(self._url, auth=auth)
 


### PR DESCRIPTION
# SSL verification
through `CERT_PATH` you can set the path to the CA_BUNDLE [according to this docs](https://2.python-requests.org/en/v1.1.0/user/advanced/#ssl-cert-verification) 
> You can also pass verify the path to a CA_BUNDLE file for private certs. You can also set the REQUESTS_CA_BUNDLE environment variable.

When you set it to `true` or `false` it then either skips or enable the `verify` of the ssl.
Since it's enabled by default as the current version, I tried my best to make it a non breaking change

If you think all is good I can adapt the `README` 